### PR TITLE
Move using of cases.Title into function

### DIFF
--- a/pkg/connector/application.go
+++ b/pkg/connector/application.go
@@ -34,7 +34,7 @@ func applicationResource(ctx context.Context, application *splunk.Application, p
 		return nil, fmt.Errorf("splunk-connector: %w", err)
 	}
 
-	displayName := titleCaser.String(application.Name)
+	displayName := titleCase(application.Name)
 	resource, err := rs.NewResource(
 		displayName,
 		resourceTypeApplication,

--- a/pkg/connector/deployment.go
+++ b/pkg/connector/deployment.go
@@ -26,7 +26,7 @@ func (d *deploymentResourceType) ResourceType(_ context.Context) *v2.ResourceTyp
 
 // deploymentResource creates a new connector resource for a Splunk Deployment under which all other resources are scoped.
 func deploymentResource(ctx context.Context, deployment string) (*v2.Resource, error) {
-	displayName := titleCaser.String(deployment)
+	displayName := titleCase(deployment)
 
 	resource, err := rs.NewResource(
 		displayName,

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -13,7 +13,11 @@ import (
 
 const ResourcesPageSize = 50
 
-var titleCaser = cases.Title(language.English)
+func titleCase(s string) string {
+	titleCaser := cases.Title(language.English)
+
+	return titleCaser.String(s)
+}
 
 func annotationsForUserResourceType() annotations.Annotations {
 	annos := annotations.Annotations{}

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -32,7 +32,7 @@ func roleResource(ctx context.Context, role *splunk.Role, parentResourceID *v2.R
 		return nil, fmt.Errorf("splunk-connector: %w", err)
 	}
 
-	displayName := titleCaser.String(role.Name)
+	displayName := titleCase(role.Name)
 
 	// merge role.capabilities and role.imported_capabilities and join into a string
 	roleCapabilities := append([]string(nil), role.Content.Capabilities...)


### PR DESCRIPTION
Instead of using one common instance of `Caser`, it creates new instance each time it formats the strings. Resolves https://github.com/ConductorOne/baton-splunk/issues/5