### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-splunk/main.go
+++ b/cmd/baton-splunk/main.go
@@ -67,6 +67,7 @@ func getConnector(ctx context.Context, c *cfg.Splunk) (types.ConnectorServer, er
 			Unsafe:  c.Unsafe,
 			Verbose: c.Verbose,
 			Cloud:   c.Cloud,
+			BaseURL: c.BaseUrl,
 		},
 		c.Deployments,
 	)

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -11,6 +11,7 @@ type Splunk struct {
 	Verbose bool `mapstructure:"verbose"`
 	Cloud bool `mapstructure:"cloud"`
 	Deployments []string `mapstructure:"deployments"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Splunk) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Splunk API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,7 @@ var (
 	BaseURL = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Splunk API URL (for testing)"),
+		field.WithHidden(true),
 	)
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,10 @@ var (
 		"deployments",
 		field.WithDescription("Limit syncing to specific deployments by specifying cloud deployment names or IP addresses of on-premise deployments."),
 	)
+	BaseURL = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Splunk API URL (for testing)"),
+	)
 )
 
 //go:generate go run ./gen
@@ -52,4 +56,5 @@ var Config = field.NewConfiguration([]field.SchemaField{
 	Verbose,
 	Cloud,
 	Deployments,
+	BaseURL,
 })

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -107,6 +107,7 @@ type CLIConfig struct {
 	Unsafe  bool
 	Verbose bool
 	Cloud   bool
+	BaseURL string
 }
 
 // New returns the Splunk connector.
@@ -134,7 +135,7 @@ func New(ctx context.Context, auth string, config CLIConfig, deployments []strin
 	}
 
 	return &Splunk{
-		client:      splunk.NewClient(httpClient, auth, config.Cloud),
+		client:      splunk.NewClient(httpClient, auth, config.Cloud, config.BaseURL),
 		verbose:     config.Verbose,
 		cloud:       config.Cloud,
 		deployments: deployments,

--- a/pkg/splunk/client.go
+++ b/pkg/splunk/client.go
@@ -35,6 +35,7 @@ type Client struct {
 	Auth       string
 	Cloud      bool
 	Deployment string
+	BaseURL    string
 }
 
 type PaginationData struct {
@@ -53,12 +54,13 @@ type Response[T any] struct {
 	PaginationData `json:"paging"`
 }
 
-func NewClient(httpClient *http.Client, auth string, cloud bool) *Client {
+func NewClient(httpClient *http.Client, auth string, cloud bool, baseURL string) *Client {
 	return &Client{
 		httpClient: httpClient,
 		Auth:       auth,
 		Cloud:      cloud,
 		Deployment: Localhost,
+		BaseURL:    baseURL,
 	}
 }
 
@@ -76,11 +78,13 @@ func (c *Client) ResetPointer() {
 
 // GetUrl returns the full URL for the given endpoint based on platform.
 func (c *Client) CreateUrl(endpoint string) string {
+	if c.BaseURL != "" {
+		return strings.TrimSuffix(c.BaseURL, "/") + endpoint
+	}
 	if c.Cloud {
 		return fmt.Sprintf(CloudBaseURL, c.Deployment) + endpoint
-	} else {
-		return fmt.Sprintf(BaseURL, c.Deployment) + endpoint
 	}
+	return fmt.Sprintf(BaseURL, c.Deployment) + endpoint
 }
 
 func (c *Client) IsCloudPlatform() bool {

--- a/pkg/splunk/client.go
+++ b/pkg/splunk/client.go
@@ -393,7 +393,7 @@ func (c *Client) doRequest(
 	req.Header.Set("content-type", "application/json")
 	req.Header.Set("Authorization", c.Auth)
 
-	rawResponse, err := c.httpClient.Do(req)
+	rawResponse, err := c.httpClient.Do(req) //nolint:gosec,nolintlint // G704: URL constructed from trusted config
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-splunk/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/splunk/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-splunk --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.