### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a Splunk connector
 og:title: Set up a Splunk connector - C1 docs
-og:description: Integrate your Splunk Enterprise server with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for Splunk Enterprise. Integrate your Splunk Enterprise server with C1 to run user access reviews (UARs), enable just-in-time access requests, and automatically provision and deprovision access.
+og:description: "C1 provides identity governance for Splunk. Integrate your Splunk instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for Splunk. Integrate your Splunk instance with C1 for unified visibility and governance over user access."
 sidebarTitle: Splunk
 ---
 
@@ -58,7 +58,7 @@ Fill out the form and click **Create**.
 The token is generated. Carefully copy and save the token value. 
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Splunk connector 
 
@@ -197,7 +197,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Splunk connector is now pulling access data into C1.
+**Done.** Your Splunk connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines