### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -51,7 +51,8 @@ func roleResource(ctx context.Context, role *splunk.Role, parentResourceID *v2.R
 		displayName,
 		resourceTypeRole,
 		roleID,
-		[]rs.GroupTraitOption{rs.WithGroupProfile(profile)},
+		[]rs.GroupTraitOption{},
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {
@@ -122,12 +123,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, pt
 		return nil, "", nil, err
 	}
 
-	roleTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, "", nil, err
-	}
-
-	roleName, ok := rs.GetProfileStringValue(roleTrait.Profile, "role_name")
+	roleName, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "role_name")
 	if !ok {
 		return nil, "", nil, fmt.Errorf("splunk-connector: error parsing role name from role profile")
 	}

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -39,9 +39,9 @@ func userResource(ctx context.Context, user *splunk.User, parentResourceID *v2.R
 		userID,
 		[]resource.UserTraitOption{
 			resource.WithEmail(user.Content.Email, true),
-			resource.WithUserProfile(profile),
-			resource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
 		},
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
 		resource.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
